### PR TITLE
fix: point plugin skills entries at directories, not SKILL.md files

### DIFF
--- a/plugins/iq-adk-ts/.claude-plugin/plugin.json
+++ b/plugins/iq-adk-ts/.claude-plugin/plugin.json
@@ -7,9 +7,9 @@
     "email": "dev@iq.wiki"
   },
   "skills": [
-    "./skills/adk-ts-docs-writer/SKILL.md",
-    "./skills/adk-ts-readme-writer/SKILL.md",
-    "./skills/adk-ts-style-guide/SKILL.md"
+    "./skills/adk-ts-docs-writer",
+    "./skills/adk-ts-readme-writer",
+    "./skills/adk-ts-style-guide"
   ],
   "agents": [
     "./agents/docs-freshness-checker.md",

--- a/plugins/iq-mcps/.claude-plugin/plugin.json
+++ b/plugins/iq-mcps/.claude-plugin/plugin.json
@@ -7,6 +7,6 @@
     "email": "dev@iq.wiki"
   },
   "skills": [
-    "./skills/mcp-development/SKILL.md"
+    "./skills/mcp-development"
   ]
 }

--- a/plugins/iq-nestjs/.claude-plugin/plugin.json
+++ b/plugins/iq-nestjs/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "dev@iq.wiki"
   },
   "skills": [
-    "./skills/nestjs/SKILL.md",
-    "./skills/database/SKILL.md",
-    "./skills/testing/SKILL.md"
+    "./skills/nestjs",
+    "./skills/database",
+    "./skills/testing"
   ]
 }

--- a/plugins/iq-nextjs/.claude-plugin/plugin.json
+++ b/plugins/iq-nextjs/.claude-plugin/plugin.json
@@ -7,12 +7,12 @@
     "email": "dev@iq.wiki"
   },
   "skills": [
-    "./skills/nextjs/SKILL.md",
-    "./skills/design/SKILL.md",
-    "./skills/database/SKILL.md",
-    "./skills/auth/SKILL.md",
-    "./skills/iq-gateway/SKILL.md",
-    "./skills/testing/SKILL.md",
-    "./skills/agent-browser/SKILL.md"
+    "./skills/nextjs",
+    "./skills/design",
+    "./skills/database",
+    "./skills/auth",
+    "./skills/iq-gateway",
+    "./skills/testing",
+    "./skills/agent-browser"
   ]
 }


### PR DESCRIPTION
## Problem

The plugin loader expects each `skills` entry in `plugin.json` to be a **directory** containing a `SKILL.md`, but the manifests point at the `SKILL.md` file itself. Every skill therefore fails to load:

> skills load failed from ./skills/nestjs/SKILL.md: path is a file; skills entries must be directories containing SKILL.md — point to the parent directory './skills/nestjs' instead

This is silent in normal use — the skills just never load. It only surfaced via `/doctor`, and only for `iq-nestjs` because that was the one installed plugin. The other three plugins that declare skills carry the identical latent bug.

## Fix

Point every `skills` entry at its parent directory across all four plugins:

- `iq-nestjs` (3 skills)
- `iq-adk-ts` (3 skills)
- `iq-mcps` (1 skill)
- `iq-nextjs` (7 skills)

## Verification

- All 14 referenced skill directories confirmed to contain `SKILL.md`.
- All four `plugin.json` files validated as well-formed JSON.